### PR TITLE
use https for git url

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -4,5 +4,5 @@
   "homepage": "https://github.com/andreioprisan/twilio-meteor",
   "author": "Andrei Oprisan (http://andrei.oprisan.com)",
   "version": "1.1.0",
-  "git": "http://github.com/andreioprisan/twilio-meteor.git"
+  "git": "https://github.com/andreioprisan/twilio-meteor.git"
 }


### PR DESCRIPTION
Just had a weird situation where meteorite would block when trying to clone this package on my test server.   Tracked it down to the use of "http" vs "https" for the `git clone` call which is set by the smart.json file.  Changing the call to "https" fixes the issue and lets `mrt` complete normally.

Looking more into it, I'm guessing its something to do with the git command itself and network access.  `mrt` should report the issue but does not (i'll look into that separately).

Running the command that `mrt` is running behind the scenes:

``` bash
$ git clone http://github.com/andreioprisan/twilio-meteor.git
```

on a Rackspace cloud server (my test server) yields:

```
Initialized empty Git repository in /home/rack-user/tmp/twilio-meteor/.git/
error: RPC failed; result=22, HTTP code = 405
```

and a hung process.

Executing the same command on ec2 or osx completes successfully with no errors.
